### PR TITLE
Add ParameterStoreClient for config initialization

### DIFF
--- a/config/helper_test.go
+++ b/config/helper_test.go
@@ -76,6 +76,7 @@ func TestParameterStoreConfig_Init(t *testing.T) {
 		expectedValue        string
 		expectPanic          bool
 		expectedPanicMessage string
+		client               ParameterStoreClient
 	}{
 		{
 			name: "Value already present",
@@ -84,6 +85,7 @@ func TestParameterStoreConfig_Init(t *testing.T) {
 				ParameterStoreSecret:   testSecret,
 				EnvironmentVariableKey: testEnvKey,
 			},
+			client:            ParameterStoreClient{Host: testHost, Port: testPort, Timeout: testTimeout},
 			prePopulatedValue: "pre-filled-value",
 			mockRetrieve: func(ctx context.Context, ServerAddress string, AuthenticationPassword string, key string, opts ...grpc.DialOption) (val string, err error) {
 				t.Errorf("grpcSimpleRetrieveFunc should not be called when value is pre-filled")
@@ -107,6 +109,7 @@ func TestParameterStoreConfig_Init(t *testing.T) {
 				ParameterStoreSecret:   testSecret,
 				EnvironmentVariableKey: testEnvKey,
 			},
+			client:        ParameterStoreClient{Host: testHost, Port: testPort, Timeout: testTimeout},
 			useEmptyValue: true,
 			mockRetrieve: func(ctx context.Context, ServerAddress string, AuthenticationPassword string, key string, opts ...grpc.DialOption) (val string, err error) {
 				t.Errorf("grpcSimpleRetrieveFunc should not be called when UseEmptyValue is true and value is initially empty")
@@ -130,6 +133,7 @@ func TestParameterStoreConfig_Init(t *testing.T) {
 				ParameterStoreSecret:   testSecret,
 				EnvironmentVariableKey: testEnvKey,
 			},
+			client: ParameterStoreClient{Host: testHost, Port: testPort, Timeout: testTimeout},
 			mockRetrieve: func(ctx context.Context, ServerAddress string, AuthenticationPassword string, key string, opts ...grpc.DialOption) (val string, err error) {
 				assert.Equal(t, testKey, key)
 				assert.Equal(t, testSecret, AuthenticationPassword)
@@ -153,10 +157,8 @@ func TestParameterStoreConfig_Init(t *testing.T) {
 				ParameterStoreKey:      testKey,
 				ParameterStoreSecret:   testSecret,
 				EnvironmentVariableKey: testEnvKey,
-				ClientCertFile:         dummyClientCert,
-				ClientKeyFile:          dummyClientKey,
-				CACertFile:             dummyCACert,
 			},
+			client: ParameterStoreClient{Host: testHost, Port: testPort, Timeout: testTimeout, ClientCertFile: dummyClientCert, ClientKeyFile: dummyClientKey, CACertFile: dummyCACert},
 			mockRetrieve: func(ctx context.Context, ServerAddress string, AuthenticationPassword string, key string, opts ...grpc.DialOption) (val string, err error) {
 				t.Errorf("grpcSimpleRetrieveFunc should not be called when mTLS certs are provided")
 				return "", errors.New("non-mTLS func called unexpectedly")
@@ -184,6 +186,7 @@ func TestParameterStoreConfig_Init(t *testing.T) {
 				ParameterStoreSecret:   testSecret,
 				EnvironmentVariableKey: testEnvKey,
 			},
+			client: ParameterStoreClient{Host: testHost, Port: testPort, Timeout: testTimeout},
 			mockRetrieve: func(ctx context.Context, ServerAddress string, AuthenticationPassword string, key string, opts ...grpc.DialOption) (val string, err error) {
 				select {
 				case <-ctx.Done():
@@ -210,10 +213,8 @@ func TestParameterStoreConfig_Init(t *testing.T) {
 				ParameterStoreKey:      testKey,
 				ParameterStoreSecret:   testSecret,
 				EnvironmentVariableKey: testEnvKey,
-				ClientCertFile:         dummyClientCert,
-				ClientKeyFile:          dummyClientKey,
-				CACertFile:             dummyCACert,
 			},
+			client: ParameterStoreClient{Host: testHost, Port: testPort, Timeout: testTimeout, ClientCertFile: dummyClientCert, ClientKeyFile: dummyClientKey, CACertFile: dummyCACert},
 			mockRetrieve: func(ctx context.Context, ServerAddress string, AuthenticationPassword string, key string, opts ...grpc.DialOption) (val string, err error) {
 				t.Errorf("grpcSimpleRetrieveFunc should not be called")
 				return "", errors.New("non-mTLS func called unexpectedly")
@@ -242,6 +243,7 @@ func TestParameterStoreConfig_Init(t *testing.T) {
 				ParameterStoreSecret:   testSecret,
 				EnvironmentVariableKey: testEnvKey,
 			},
+			client: ParameterStoreClient{Host: testHost, Port: testPort, Timeout: testTimeout},
 			mockRetrieve: func(ctx context.Context, ServerAddress string, AuthenticationPassword string, key string, opts ...grpc.DialOption) (val string, err error) {
 				return "", errors.New("some-grpc-error")
 			},
@@ -262,10 +264,8 @@ func TestParameterStoreConfig_Init(t *testing.T) {
 				ParameterStoreKey:      testKey,
 				ParameterStoreSecret:   testSecret,
 				EnvironmentVariableKey: testEnvKey,
-				ClientCertFile:         dummyClientCert,
-				ClientKeyFile:          dummyClientKey,
-				CACertFile:             dummyCACert,
 			},
+			client: ParameterStoreClient{Host: testHost, Port: testPort, Timeout: testTimeout, ClientCertFile: dummyClientCert, ClientKeyFile: dummyClientKey, CACertFile: dummyCACert},
 			mockRetrieve: func(ctx context.Context, ServerAddress string, AuthenticationPassword string, key string, opts ...grpc.DialOption) (val string, err error) {
 				t.Errorf("grpcSimpleRetrieveFunc should not be called")
 				return "", errors.New("non-mTLS func called unexpectedly")
@@ -288,6 +288,7 @@ func TestParameterStoreConfig_Init(t *testing.T) {
 				ParameterStoreSecret:   testSecret,
 				EnvironmentVariableKey: testEnvKey,
 			},
+			client: ParameterStoreClient{Host: testHost, Port: testPort, Timeout: testTimeout},
 			mockRetrieve: func(ctx context.Context, ServerAddress string, AuthenticationPassword string, key string, opts ...grpc.DialOption) (val string, err error) {
 				return "", nil // Success, but empty value
 			},
@@ -308,10 +309,8 @@ func TestParameterStoreConfig_Init(t *testing.T) {
 				ParameterStoreKey:      testKey,
 				ParameterStoreSecret:   testSecret,
 				EnvironmentVariableKey: testEnvKey,
-				ClientCertFile:         dummyClientCert,
-				ClientKeyFile:          dummyClientKey,
-				CACertFile:             dummyCACert,
 			},
+			client: ParameterStoreClient{Host: testHost, Port: testPort, Timeout: testTimeout, ClientCertFile: dummyClientCert, ClientKeyFile: dummyClientKey, CACertFile: dummyCACert},
 			mockRetrieve: func(ctx context.Context, ServerAddress string, AuthenticationPassword string, key string, opts ...grpc.DialOption) (val string, err error) {
 				t.Errorf("grpcSimpleRetrieveFunc should not be called")
 				return "", errors.New("non-mTLS func called unexpectedly")
@@ -334,6 +333,7 @@ func TestParameterStoreConfig_Init(t *testing.T) {
 				ParameterStoreSecret:   testSecret,
 				EnvironmentVariableKey: testEnvKey,
 			},
+			client: ParameterStoreClient{Host: testHost, Port: testPort, Timeout: testTimeout},
 			mockRetrieve: func(ctx context.Context, ServerAddress string, AuthenticationPassword string, key string, opts ...grpc.DialOption) (val string, err error) {
 				return "", errors.New("param-store-failed")
 			},
@@ -354,10 +354,8 @@ func TestParameterStoreConfig_Init(t *testing.T) {
 				ParameterStoreKey:      testKey,
 				ParameterStoreSecret:   testSecret,
 				EnvironmentVariableKey: testEnvKey,
-				ClientCertFile:         dummyClientCert,
-				ClientKeyFile:          dummyClientKey,
-				CACertFile:             dummyCACert,
 			},
+			client: ParameterStoreClient{Host: testHost, Port: testPort, Timeout: testTimeout, ClientCertFile: dummyClientCert, ClientKeyFile: dummyClientKey, CACertFile: dummyCACert},
 			mockRetrieve: func(ctx context.Context, ServerAddress string, AuthenticationPassword string, key string, opts ...grpc.DialOption) (val string, err error) {
 				t.Errorf("grpcSimpleRetrieveFunc should not be called")
 				return "", errors.New("non-mTLS func called unexpectedly")
@@ -392,11 +390,11 @@ func TestParameterStoreConfig_Init(t *testing.T) {
 
 			if tt.expectPanic {
 				assert.PanicsWithError(t, tt.expectedPanicMessage, func() {
-					config.Init(testHost, testPort, testTimeout)
+					config.Init(&tt.client)
 				}, "Expected Init to panic with specific error")
 			} else {
 				assert.NotPanics(t, func() {
-					config.Init(testHost, testPort, testTimeout)
+					config.Init(&tt.client)
 				}, "Expected Init not to panic")
 				assert.Equal(t, tt.expectedValue, config.ParameterStoreValue, "ParameterStoreValue mismatch")
 			}

--- a/config/psclient.go
+++ b/config/psclient.go
@@ -1,0 +1,43 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// ParameterStoreClient holds connection details for the parameter store.
+type ParameterStoreClient struct {
+	Host           string
+	Port           int
+	Timeout        time.Duration
+	ClientCertFile string
+	ClientKeyFile  string
+	CACertFile     string
+}
+
+// retrieve fetches a value for the given key using the provided secret.
+// It automatically uses mTLS if certificate paths are present.
+func (c *ParameterStoreClient) retrieve(key, secret string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+
+	serverAddress := fmt.Sprintf("%s:%v", c.Host, c.Port)
+
+	var (
+		value string
+		err   error
+	)
+
+	if c.ClientCertFile != "" && c.ClientKeyFile != "" && c.CACertFile != "" {
+		value, err = grpcSimpleRetrieveWithMTLSFunc(ctx, serverAddress, secret, key, c.ClientCertFile, c.ClientKeyFile, c.CACertFile)
+	} else {
+		value, err = grpcSimpleRetrieveFunc(ctx, serverAddress, secret, key)
+	}
+
+	if err != nil && ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("parameter store operation timed out: %w", err)
+	}
+
+	return value, err
+}


### PR DESCRIPTION
## Summary
- introduce `ParameterStoreClient` struct for connection details
- move retrieval logic into `(*ParameterStoreClient).retrieve`
- update `setValueIfEmpty` and `ParameterStoreConfig.Init` to use the client
- adjust tests and README examples for the new API

## Testing
- `go test ./...`