### PR TITLE
Fix gRPC dialer for deprecated API

### DIFF
--- a/client/grpc_client.go
+++ b/client/grpc_client.go
@@ -68,7 +68,8 @@ func GrpcimpleRetrieve(ctx context.Context, ServerAddress string, Authentication
 	// Create a client connection to the gRPC server using the combined options,
 	// via GRPCDialContextFunc (which defaults to grpc.NewClient).
 	// See the comment on GRPCDialContextFunc for how context.Context is handled.
-	conn, err := GRPCDialContextFunc(ServerAddress, allOpts...)
+	target := "passthrough:///" + ServerAddress
+	conn, err := GRPCDialContextFunc(target, allOpts...)
 	if err != nil {
 		log.Printf("did not connect to %s: %v", ServerAddress, err)
 		return "", fmt.Errorf("failed to connect to gRPC server at %s: %w", ServerAddress, err)
@@ -174,7 +175,8 @@ func GrpcSimpleRetrieveWithMTLS(ctx context.Context, ServerAddress string, Authe
 	// Create a client connection to the gRPC server using the combined options,
 	// via GRPCDialContextFunc (which defaults to grpc.NewClient).
 	// See the comment on GRPCDialContextFunc for how context.Context is handled.
-	conn, err := GRPCDialContextFunc(ServerAddress, allOpts...)
+	target := "passthrough:///" + ServerAddress
+	conn, err := GRPCDialContextFunc(target, allOpts...)
 	if err != nil {
 		log.Printf("did not connect to %s: %v", ServerAddress, err)
 		return "", fmt.Errorf("failed to connect to gRPC server at %s: %w", ServerAddress, err)
@@ -227,7 +229,8 @@ func GrpcSimpleStore(ctx context.Context, ServerAddress string, AuthenticationPa
 	// Create a client connection to the gRPC server using the combined options,
 	// via GRPCDialContextFunc (which defaults to grpc.NewClient).
 	// See the comment on GRPCDialContextFunc for how context.Context is handled.
-	conn, err := GRPCDialContextFunc(ServerAddress, allOpts...)
+	target := "passthrough:///" + ServerAddress
+	conn, err := GRPCDialContextFunc(target, allOpts...)
 	if err != nil {
 		log.Printf("did not connect to %s: %v", ServerAddress, err)
 		return fmt.Errorf("failed to connect to gRPC server at %s: %w", ServerAddress, err)
@@ -303,7 +306,8 @@ func GrpcSimpleStoreWithMTLS(ctx context.Context, ServerAddress string, Authenti
 	// Create a client connection to the gRPC server using the combined options,
 	// via GRPCDialContextFunc (which defaults to grpc.NewClient).
 	// See the comment on GRPCDialContextFunc for how context.Context is handled.
-	conn, err := GRPCDialContextFunc(ServerAddress, allOpts...)
+	target := "passthrough:///" + ServerAddress
+	conn, err := GRPCDialContextFunc(target, allOpts...)
 	if err != nil {
 		log.Printf("did not connect to %s: %v", ServerAddress, err)
 		return fmt.Errorf("failed to connect to gRPC server at %s: %w", ServerAddress, err)

--- a/client/grpc_client_test.go
+++ b/client/grpc_client_test.go
@@ -265,7 +265,8 @@ func TestGrpcimpleRetrieve(t *testing.T) {
 		_, err := GrpcimpleRetrieve(ctx, "bufnet", mockPassword, mockKey, opts...)
 
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to connect", "Expected connection error")
+		// Error message may vary, but should indicate a connection issue
+		assert.Contains(t, err.Error(), "connection error", "Expected connection error")
 
 		// Restart server for subsequent tests if needed (though defer handles it for the whole function)
 		// stopServer = startMockServer(mockSrv)


### PR DESCRIPTION
## Summary
- keep using `grpc.NewClient` but prefix targets with `passthrough:///`
- adjust connection error test for new dial behavior

## Testing
- `go test ./...`