### PR TITLE
Default retrieval func for config client

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,19 @@ func main() {
         paramStorePort := 50051       // Replace with your parameter store port
         paramStoreTimeout := 3 * time.Second
 
-        client := &config.ParameterStoreClient{
-                Host:    paramStoreHost,
-                Port:    paramStorePort,
-                Timeout: paramStoreTimeout,
+        // You can build the client manually or use NewParameterStoreClient.
+        // NewParameterStoreClient sets RetrieveFunc to client.RetrieveWithClient
+        // so Init works without extra configuration.
+        client, err := config.NewParameterStoreClient(
+                paramStoreHost,
+                paramStorePort,
+                paramStoreTimeout,
+                config.CertificateSource{}, // client cert
+                config.CertificateSource{}, // client key
+                config.CertificateSource{}, // CA cert
+        )
+        if err != nil {
+                log.Fatalf("failed to create client: %v", err)
         }
 
 	// Define the configuration structure

--- a/config/psclient.go
+++ b/config/psclient.go
@@ -4,7 +4,11 @@ import (
 	"fmt"
 	"os"
 	"time"
+	_ "unsafe"
 )
+
+//go:linkname defaultRetrieveFunc github.com/Suhaibinator/SuhaibParameterStoreClient/client.RetrieveWithClient
+var defaultRetrieveFunc func(c *ParameterStoreClient, key, secret string) (string, error)
 
 // CertificateSource holds either a file path to a certificate/key or its raw byte content.
 type CertificateSource struct {
@@ -82,12 +86,13 @@ func NewParameterStoreClient(
 	}
 
 	return &ParameterStoreClient{
-		Host:       host,
-		Port:       port,
-		Timeout:    timeout,
-		ClientCert: clientCert,
-		ClientKey:  clientKey,
-		CACert:     caCert,
+		Host:         host,
+		Port:         port,
+		Timeout:      timeout,
+		ClientCert:   clientCert,
+		ClientKey:    clientKey,
+		CACert:       caCert,
+		RetrieveFunc: defaultRetrieveFunc,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary
- assign `RetrieveFunc` to a linked `client.RetrieveWithClient` in `NewParameterStoreClient`
- show using `NewParameterStoreClient` in README

## Testing
- `go test ./...`
