### PR TITLE
Reduce grpc dial duplication

### DIFF
--- a/client/grpc_client.go
+++ b/client/grpc_client.go
@@ -65,6 +65,25 @@ func RetrieveWithClient(c *psconfig.ParameterStoreClient, key, secret string) (s
 // Default timeout for gRPC operations if no context deadline is set.
 const defaultGrpcTimeout = 5 * time.Second
 
+// dial sets up a connection to the given gRPC server using the supplied options.
+// It wraps GRPCDialContextFunc and provides consistent error handling across
+// client helpers.
+func dial(ctx context.Context, serverAddr string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	if err := ctx.Err(); err != nil {
+		log.Printf("gRPC dial context for %s already expired/canceled: %v", serverAddr, err)
+		return nil, fmt.Errorf("gRPC dial context for %s already expired/canceled: %w", serverAddr, err)
+	}
+
+	target := "passthrough:///" + serverAddr
+	conn, err := GRPCDialContextFunc(target, opts...)
+	if err != nil {
+		log.Printf("did not connect to %s: %v", serverAddr, err)
+		return nil, fmt.Errorf("failed to connect to gRPC server at %s: %w", serverAddr, err)
+	}
+
+	return conn, nil
+}
+
 // GrpcSimpleRetrieve retrieves a value from the parameter store using gRPC.
 // It accepts a context for timeout/cancellation control and optional grpc.DialOptions.
 func GrpcSimpleRetrieve(ctx context.Context, ServerAddress string, AuthenticationPassword string, key string, opts ...grpc.DialOption) (val string, err error) { //nolint:all // Existing function
@@ -83,20 +102,11 @@ func GrpcSimpleRetrieve(ctx context.Context, ServerAddress string, Authenticatio
 	// Append any additional options passed by the caller.
 	allOpts := append(defaultOpts, opts...)
 
-	// Check if the context is already done before attempting to dial.
-	if err := ctx.Err(); err != nil {
-		log.Printf("gRPC dial context for %s already expired/canceled: %v", ServerAddress, err)
-		return "", fmt.Errorf("gRPC dial context for %s already expired/canceled: %w", ServerAddress, err)
-	}
-
-	// Create a client connection to the gRPC server using the combined options,
-	// via GRPCDialContextFunc (which defaults to grpc.NewClient).
-	// See the comment on GRPCDialContextFunc for how context.Context is handled.
-	target := "passthrough:///" + ServerAddress
-	conn, err := GRPCDialContextFunc(target, allOpts...)
+	// Establish connection using the helper dial function.
+	var conn *grpc.ClientConn
+	conn, err = dial(ctx, ServerAddress, allOpts...)
 	if err != nil {
-		log.Printf("did not connect to %s: %v", ServerAddress, err)
-		return "", fmt.Errorf("failed to connect to gRPC server at %s: %w", ServerAddress, err)
+		return "", err
 	}
 	defer conn.Close()
 
@@ -195,20 +205,11 @@ func GrpcSimpleRetrieveWithMTLS(ctx context.Context, ServerAddress string, Authe
 	// Append any additional options passed by the caller.
 	allOpts := append(defaultOpts, opts...)
 
-	// Check if the context is already done before attempting to dial.
-	if err := ctx.Err(); err != nil {
-		log.Printf("gRPC dial context for %s already expired/canceled: %v", ServerAddress, err)
-		return "", fmt.Errorf("gRPC dial context for %s already expired/canceled: %w", ServerAddress, err)
-	}
-
-	// Create a client connection to the gRPC server using the combined options,
-	// via GRPCDialContextFunc (which defaults to grpc.NewClient).
-	// See the comment on GRPCDialContextFunc for how context.Context is handled.
-	target := "passthrough:///" + ServerAddress
-	conn, err := GRPCDialContextFunc(target, allOpts...)
+	// Establish connection using the helper dial function.
+	var conn *grpc.ClientConn
+	conn, err = dial(ctx, ServerAddress, allOpts...)
 	if err != nil {
-		log.Printf("did not connect to %s: %v", ServerAddress, err)
-		return "", fmt.Errorf("failed to connect to gRPC server at %s: %w", ServerAddress, err)
+		return "", err
 	}
 	defer conn.Close()
 
@@ -249,20 +250,11 @@ func GrpcSimpleStore(ctx context.Context, ServerAddress string, AuthenticationPa
 	// Append any additional options passed by the caller.
 	allOpts := append(defaultOpts, opts...)
 
-	// Check if the context is already done before attempting to dial.
-	if err := ctx.Err(); err != nil {
-		log.Printf("gRPC dial context for %s already expired/canceled: %v", ServerAddress, err)
-		return fmt.Errorf("gRPC dial context for %s already expired/canceled: %w", ServerAddress, err)
-	}
-
-	// Create a client connection to the gRPC server using the combined options,
-	// via GRPCDialContextFunc (which defaults to grpc.NewClient).
-	// See the comment on GRPCDialContextFunc for how context.Context is handled.
-	target := "passthrough:///" + ServerAddress
-	conn, err := GRPCDialContextFunc(target, allOpts...)
+	// Establish connection using the helper dial function.
+	var conn *grpc.ClientConn
+	conn, err = dial(ctx, ServerAddress, allOpts...)
 	if err != nil {
-		log.Printf("did not connect to %s: %v", ServerAddress, err)
-		return fmt.Errorf("failed to connect to gRPC server at %s: %w", ServerAddress, err)
+		return err
 	}
 	defer conn.Close()
 
@@ -326,20 +318,11 @@ func GrpcSimpleStoreWithMTLS(ctx context.Context, ServerAddress string, Authenti
 	// Append any additional options passed by the caller.
 	allOpts := append(defaultOpts, opts...)
 
-	// Check if the context is already done before attempting to dial.
-	if err := ctx.Err(); err != nil {
-		log.Printf("gRPC dial context for %s already expired/canceled: %v", ServerAddress, err)
-		return fmt.Errorf("gRPC dial context for %s already expired/canceled: %w", ServerAddress, err)
-	}
-
-	// Create a client connection to the gRPC server using the combined options,
-	// via GRPCDialContextFunc (which defaults to grpc.NewClient).
-	// See the comment on GRPCDialContextFunc for how context.Context is handled.
-	target := "passthrough:///" + ServerAddress
-	conn, err := GRPCDialContextFunc(target, allOpts...)
+	// Establish connection using the helper dial function.
+	var conn *grpc.ClientConn
+	conn, err = dial(ctx, ServerAddress, allOpts...)
 	if err != nil {
-		log.Printf("did not connect to %s: %v", ServerAddress, err)
-		return fmt.Errorf("failed to connect to gRPC server at %s: %w", ServerAddress, err)
+		return err
 	}
 	defer conn.Close()
 


### PR DESCRIPTION
## Summary
- add `dial` helper for repeated grpc connection logic
- use `dial` in simple retrieve/store functions

## Testing
- `go test ./...`